### PR TITLE
Feature 6433: Mogelijkheid om adjustments aan te passen

### DIFF
--- a/spree_service_fee.gemspec
+++ b/spree_service_fee.gemspec
@@ -2,7 +2,7 @@
 Gem::Specification.new do |s|
   s.platform    = Gem::Platform::RUBY
   s.name        = 'spree_service_fee'
-  s.version     = '1.0.3'
+  s.version     = '1.0.4'
   s.summary     = ''
   s.description = ''
   s.required_ruby_version = '>= 2.1.0'


### PR DESCRIPTION
http://redmine.cg.lan/issues/6433

> Het kan voorkomen dat een klant te weinig betaalt als de transactiekosten wijzigen, in dit geval moet support de adjustment aan kunnen passen of een nieuwe kunnen maken om de order alsnog door te kunnen zetten.

# Hoe te testen

Dit is te testen in de Omnia applicatie.

1. Voeg een service fee toe
2. Maak een order waar deze service fee voor geldt
3. Pas in de order de service fee adjustment aan. Deze moet nu succesvol bijwerken naar de nieuwe waarde (in plaats van resetten naar de oorspronkelijke waarde)